### PR TITLE
fix: avoid undefined stroke width

### DIFF
--- a/src/views/components/Atoms/Icon/index.tsx
+++ b/src/views/components/Atoms/Icon/index.tsx
@@ -298,9 +298,11 @@ export default function Icon({
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       className={`${styles.icon} ${className}`}
-      style={{ 
-        color: color,
-        '--stroke-width': strokeWidth 
+      style={{
+        color,
+        ...(strokeWidth !== undefined
+          ? { '--stroke-width': strokeWidth }
+          : {})
       } as React.CSSProperties}
     >
       {iconContent}


### PR DESCRIPTION
## Summary
- avoid setting undefined CSS variable in Icon component

## Testing
- `yarn lint` *(fails: rule '@typescript-eslint/await-thenable' requires type information)*

------
https://chatgpt.com/codex/tasks/task_e_689ff54f82c8832b9d630051a329c71e